### PR TITLE
add `--hash` support for vector / image assets

### DIFF
--- a/packages/support-flags/--hash/README.md
+++ b/packages/support-flags/--hash/README.md
@@ -1,0 +1,25 @@
+# Hash
+
+> Hash is a unique id indicator just like `--id`, but for a asset such as vector & images
+
+## Allowed on
+
+- layer with single image fill (a image)
+- a vector layer
+
+## Use with `--main`
+
+```
+vector layer 1 --hash=my-brand-logo
+vector layer 2 --hash=my-brand-logo --main
+```
+
+Now vector 1 & 2 will use the same svg data, based on vector 2's svg data (since it's marked with `--main`).
+
+- do - set one layer as main
+- don't - set multiple layer with same hash with main (will show warning)
+- don't - no main layer specified - will use the first hit item.
+
+## See also
+
+- [`--id`](../--id/README.md)

--- a/packages/support-flags/--id/README.md
+++ b/packages/support-flags/--id/README.md
@@ -8,3 +8,7 @@ by specifing the id flag, you can take advantage in below scenarios.
 - id="value" on generated html output.
 
 <!-- TODO: provide more realworld usecase -->
+
+## See also
+
+- [`--hash`](../--hash/README.md)


### PR DESCRIPTION
# Hash

> Hash is a unique id indicator just like `--id`, but for a asset such as vector & images

## Allowed on

- layer with single image fill (a image)
- a vector layer

## Use with `--main`

```
vector layer 1 --hash=my-brand-logo
vector layer 2 --hash=my-brand-logo --main
```

Now vector 1 & 2 will use the same svg data, based on vector 2's svg data (since it's marked with `--main`).

- do - set one layer as main
- don't - set multiple layer with same hash with main (will show warning)
- don't - no main layer specified - will use the first hit item.

## See also

- [`--id`](../--id/README.md)
