### PR TITLE
Support empty `target.fills` when resolving image hashes

### DIFF
--- a/editor/scaffolds/inspector/section-assets.tsx
+++ b/editor/scaffolds/inspector/section-assets.tsx
@@ -57,13 +57,12 @@ function ImageFillNodeAssetView({ node: target }: { node: ReflectSceneNode }) {
   useEffect(() => {
     if (target) {
       const images = target.fills
-        .filter(Boolean)
-        .filter((f) => f.visible)
-        .filter((f) => f.type === "IMAGE")
-        .reverse()
-        .map((f: ImagePaint) => {
-          return f.imageHash;
-        });
+        ?.flatMap((fill => {
+          if (!!fill && fill.visible && fill.type === "IMAGE") {
+            return fill.imageHash || []
+          }
+          return [];
+        })).reverse() || []
 
       service.fetch(images, { debounce: false, ensure: true }).then((data) => {
         setSrcs(Object.values(data));


### PR DESCRIPTION
1. Since `target` is `ReflectSceneNode`, `target.fills` can be empty, which can sometimes lead to crash.
2. Also, we're using multiple `.filter(...)`/`.map(...)` chains. This can be combined into `.flatMap(...)`.
3. This PR also changes type of `images` to match parameter typings for `service.fetch(...)`: `(string | null)[]` -> `string[]`

<img width="784" alt="Screenshot 2022-12-04 at 11 10 31 PM" src="https://user-images.githubusercontent.com/32605822/205495356-ac37824e-a217-4066-a68f-75c628a2037e.png">
