### PR TITLE
Support google fonts

### DIFF
--- a/editor/next.config.js
+++ b/editor/next.config.js
@@ -41,6 +41,7 @@ const packages = [
   "@code-features/documentation",
   "@code-features/component",
   "@code-features/flags",
+  "@code-features/fonts",
   // -----------------------------
 
   // reflect-ui ui framework

--- a/packages/builder-web-vanilla/export-inline-css-html-file/index.ts
+++ b/packages/builder-web-vanilla/export-inline-css-html-file/index.ts
@@ -22,6 +22,9 @@ export function export_vanilla_preview_source(
       ...config,
       // required (for safety, for consistant preview)
       disable_all_optimizations: true,
+      fonts: {
+        services: ["system", "fonts.google.com"],
+      },
     },
   });
   return builder.export();

--- a/packages/builder-web-vanilla/html-css-id-widget/html-fonts-middleware.ts
+++ b/packages/builder-web-vanilla/html-css-id-widget/html-fonts-middleware.ts
@@ -1,0 +1,62 @@
+import { TFontService, fonts } from "@code-features/fonts";
+import type { HtmlIdCssModuleBuilder } from "./html-css-id-module-builder";
+
+export function htmlFontsMiddleware(
+  builder: HtmlIdCssModuleBuilder,
+  services: ReadonlyArray<TFontService>
+) {
+  try {
+    // TODO: we need better way to get used fonts.
+    const styles = builder.partStyles();
+
+    // parse lines with "font-family: ..."
+    const matches = styles.match(/font-family:.*?;/g);
+    if (!matches) {
+      return;
+    } else {
+      const font_families = matches
+        .map((m) => {
+          return m
+            .replace(/font-family:/, "")
+            .replace(/;/, "")
+            .trim()
+            .split(",")
+            .map((f) => f.trim().replace(/"/g, "").replace(/'/g, "").trim());
+        })
+        .flat()
+        .filter((f) => f.length > 0)
+        .filter(
+          (f) =>
+            f !== "inherit" &&
+            f !== "initial" &&
+            f !== "unset" &&
+            f !== "serif" &&
+            f !== "sans-serif" &&
+            f !== "monospace" &&
+            f !== "cursive" &&
+            f !== "fantasy" &&
+            f !== "system-ui"
+        );
+
+      const resolved = fonts({
+        fonts: font_families,
+        resolution: "fonts.googleapis.com/css2",
+        services,
+      });
+
+      // create <link> tag for each font, which is going to be added to <head> tag.
+      const links = [
+        `<link rel="preconnect" href="https://fonts.googleapis.com">`,
+        `<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>`,
+        ...Object.keys(resolved).map((f) => {
+          const { urls } = resolved[f];
+          return `<link rel="stylesheet" href="${urls["*"]}">`;
+        }),
+      ];
+
+      builder.head(...links);
+    }
+  } catch (e) {
+    console.error(`error while resolving fonts from [${services.join(",")}]`);
+  }
+}

--- a/packages/support-fonts/index.ts
+++ b/packages/support-fonts/index.ts
@@ -7,11 +7,13 @@ type FontResolutions = {
   [family: string]: {
     resolution: TFontResulution;
     service: TFontService;
-    urls: ReadonlyArray<string>;
+    urls: {
+      [request: string]: string;
+    };
   };
 };
 
-type TFontResulution = "font-face" | "link";
+type TFontResulution = "fonts.googleapis.com/css2";
 
 const providers = {
   "fonts.google.com": googlefont,
@@ -42,7 +44,6 @@ export function fonts({
         result[font] = {
           resolution,
           ...resolved,
-          urls: [], // TODO:
         };
         break;
       }

--- a/packages/support-fonts/index.ts
+++ b/packages/support-fonts/index.ts
@@ -1,0 +1,8 @@
+export type TFontService = "system" | "fonts.google.com";
+
+/**
+ * resolve fonts from services
+ */
+export function fonts() {
+  //
+}

--- a/packages/support-fonts/index.ts
+++ b/packages/support-fonts/index.ts
@@ -1,8 +1,53 @@
+import { googlefont } from "./services/fonts.google.com";
+import { systemfont } from "./services/system";
+
 export type TFontService = "system" | "fonts.google.com";
+
+type FontResolutions = {
+  [family: string]: {
+    resolution: TFontResulution;
+    service: TFontService;
+    urls: ReadonlyArray<string>;
+  };
+};
+
+type TFontResulution = "font-face" | "link";
+
+const providers = {
+  "fonts.google.com": googlefont,
+  system: systemfont,
+} as const;
 
 /**
  * resolve fonts from services
  */
-export function fonts() {
-  //
+export function fonts({
+  fonts,
+  services,
+  resolution,
+}: {
+  fonts: ReadonlyArray<string>;
+  services: ReadonlyArray<TFontService>;
+  resolution: TFontResulution;
+}): FontResolutions {
+  const result: FontResolutions = {};
+
+  const resolvers = services.map((service) => {
+    return providers[service];
+  });
+  for (const font of fonts) {
+    for (const resolver of resolvers) {
+      const resolved = resolver(font);
+      if (resolved) {
+        result[font] = {
+          resolution,
+          ...resolved,
+          urls: [], // TODO:
+        };
+        break;
+      }
+    }
+  }
+
+  return result;
 }

--- a/packages/support-fonts/package.json
+++ b/packages/support-fonts/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@code-feature/fonts",
+  "version": "0.0.0",
+  "dependencies": {
+    "ufo": "^1.1.1"
+  }
+}

--- a/packages/support-fonts/package.json
+++ b/packages/support-fonts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@code-feature/fonts",
+  "name": "@code-features/fonts",
   "version": "0.0.0",
   "dependencies": {
     "ufo": "^1.1.1"

--- a/packages/support-fonts/services/fonts.google.com/fonts.json
+++ b/packages/support-fonts/services/fonts.google.com/fonts.json
@@ -1,0 +1,14333 @@
+{
+  "ABeeZee": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Abel": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Abhaya Libre": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Aboreto": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Abril Fatface": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Abyssinica SIL": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Aclonica": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Acme": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Actor": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Adamina": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Advent Pro": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Aguafina Script": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Akaya Kanadaka": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Akaya Telivigala": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Akronim": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Akshar": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Aladin": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Alata": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Alatsi": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Albert Sans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Aldrich": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Alef": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Alegreya": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Alegreya Sans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 300, 400, 500, 700, 800, 900],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 100],
+      [1, 100],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 700],
+      [1, 700],
+      [0, 800],
+      [1, 800],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Alegreya Sans SC": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 300, 400, 500, 700, 800, 900],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 100],
+      [1, 100],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 700],
+      [1, 700],
+      [0, 800],
+      [1, 800],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Alegreya SC": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 700],
+      [1, 700],
+      [0, 800],
+      [1, 800],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Aleo": {
+    "fallbacks": ["serif"],
+    "weights": [300, 400, 700],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Alex Brush": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Alexandria": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Alfa Slab One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Alice": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Alike": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Alike Angular": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Alkalami": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Alkatra": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Allan": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Allerta": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Allerta Stencil": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Allison": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Allura": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Almarai": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Almendra": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Almendra Display": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Almendra SC": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Alumni Sans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Alumni Sans Collegiate One": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Alumni Sans Inline One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Alumni Sans Pinstripe": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Amarante": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Amaranth": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Amatic SC": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Amethysta": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Amiko": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Amiri": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Amiri Quran": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Amita": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Anaheim": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Andada Pro": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 600, 700, 800],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800]
+    ]
+  },
+  "Andika": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Anek Bangla": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Anek Devanagari": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Anek Gujarati": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Anek Gurmukhi": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Anek Kannada": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Anek Latin": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Anek Malayalam": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Anek Odia": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Anek Tamil": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Anek Telugu": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Angkor": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Annie Use Your Telescope": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Anonymous Pro": {
+    "fallbacks": ["monospace"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Antic": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Antic Didone": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Antic Slab": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Anton": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Antonio": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Anybody": {
+    "fallbacks": ["cursive"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Arapey": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Arbutus": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Arbutus Slab": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Architects Daughter": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Archivo": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Archivo Black": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Archivo Narrow": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700]
+    ]
+  },
+  "Are You Serious": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Aref Ruqaa": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Aref Ruqaa Ink": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Arima": {
+    "fallbacks": ["cursive"],
+    "weights": [100, 200, 300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Arimo": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700]
+    ]
+  },
+  "Arizonia": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Armata": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Arsenal": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Artifika": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Arvo": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Arya": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Asap": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Asap Condensed": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700],
+      [0, 800],
+      [1, 800],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Asar": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Asset": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Assistant": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Astloch": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Asul": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Athiti": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Atkinson Hyperlegible": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Atma": {
+    "fallbacks": ["cursive"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Atomic Age": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Aubrey": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Audiowide": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Autour One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Average": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Average Sans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Averia Gruesa Libre": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Averia Libre": {
+    "fallbacks": ["cursive"],
+    "weights": [300, 400, 700],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Averia Sans Libre": {
+    "fallbacks": ["cursive"],
+    "weights": [300, 400, 700],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Averia Serif Libre": {
+    "fallbacks": ["cursive"],
+    "weights": [300, 400, 700],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Azeret Mono": {
+    "fallbacks": ["monospace"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "B612": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "B612 Mono": {
+    "fallbacks": ["monospace"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Babylonica": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Bad Script": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Bahiana": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Bahianita": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Bai Jamjuree": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Bakbak One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Ballet": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Baloo 2": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Baloo Bhai 2": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Baloo Bhaijaan 2": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Baloo Bhaina 2": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Baloo Chettan 2": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Baloo Da 2": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Baloo Paaji 2": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Baloo Tamma 2": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Baloo Tammudu 2": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Baloo Thambi 2": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Balsamiq Sans": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Balthazar": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Bangers": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Barlow": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 100],
+      [1, 100],
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700],
+      [0, 800],
+      [1, 800],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Barlow Condensed": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 100],
+      [1, 100],
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700],
+      [0, 800],
+      [1, 800],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Barlow Semi Condensed": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 100],
+      [1, 100],
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700],
+      [0, 800],
+      [1, 800],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Barriecito": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Barrio": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Basic": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Baskervville": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Battambang": {
+    "fallbacks": ["cursive"],
+    "weights": [100, 300, 400, 700, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 300],
+      [0, 400],
+      [0, 700],
+      [0, 900]
+    ]
+  },
+  "Baumans": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Bayon": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Be Vietnam Pro": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 100],
+      [1, 100],
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700],
+      [0, 800],
+      [1, 800],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Beau Rivage": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Bebas Neue": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Belgrano": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Bellefair": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Belleza": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Bellota": {
+    "fallbacks": ["cursive"],
+    "weights": [300, 400, 700],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Bellota Text": {
+    "fallbacks": ["cursive"],
+    "weights": [300, 400, 700],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "BenchNine": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Benne": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Bentham": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Berkshire Swash": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Besley": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Beth Ellen": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Bevan": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "BhuTuka Expanded One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Big Shoulders Display": {
+    "fallbacks": ["cursive"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Big Shoulders Inline Display": {
+    "fallbacks": ["cursive"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Big Shoulders Inline Text": {
+    "fallbacks": ["cursive"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Big Shoulders Stencil Display": {
+    "fallbacks": ["cursive"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Big Shoulders Stencil Text": {
+    "fallbacks": ["cursive"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Big Shoulders Text": {
+    "fallbacks": ["cursive"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Bigelow Rules": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Bigshot One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Bilbo": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Bilbo Swash Caps": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "BioRhyme": {
+    "fallbacks": ["serif"],
+    "weights": [200, 300, 400, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "BioRhyme Expanded": {
+    "fallbacks": ["serif"],
+    "weights": [200, 300, 400, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Birthstone": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Birthstone Bounce": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 500],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500]
+    ]
+  },
+  "Biryani": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Bitter": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "BIZ UDGothic": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "BIZ UDMincho": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "BIZ UDPGothic": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "BIZ UDPMincho": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Black And White Picture": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Black Han Sans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Black Ops One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Blaka": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Blaka Hollow": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Blaka Ink": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Blinker": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Bodoni Moda": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Bokor": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Bona Nova": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700]
+    ]
+  },
+  "Bonbon": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Bonheur Royale": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Boogaloo": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Bowlby One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Bowlby One SC": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Brawler": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Bree Serif": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Brygada 1918": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700]
+    ]
+  },
+  "Bubblegum Sans": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Bubbler One": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Buda": {
+    "fallbacks": ["cursive"],
+    "weights": [300],
+    "styles": [],
+    "variants": [[0, 300]]
+  },
+  "Buenard": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Bungee": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Bungee Hairline": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Bungee Inline": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Bungee Outline": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Bungee Shade": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Bungee Spice": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Butcherman": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Butterfly Kids": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Cabin": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700]
+    ]
+  },
+  "Cabin Condensed": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Cabin Sketch": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Caesar Dressing": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Cagliostro": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Cairo": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Cairo Play": {
+    "fallbacks": ["cursive"],
+    "weights": [200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Caladea": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Calistoga": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Calligraffitti": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Cambay": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Cambo": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Candal": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Cantarell": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Cantata One": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Cantora One": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Capriola": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Caramel": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Carattere": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Cardo": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700]
+    ]
+  },
+  "Carme": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Carrois Gothic": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Carrois Gothic SC": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Carter One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Castoro": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Catamaran": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Caudex": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Caveat": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Caveat Brush": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Cedarville Cursive": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Ceviche One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Chakra Petch": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Changa": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Changa One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Chango": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Charis SIL": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Charm": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Charmonman": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Chathura": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 300, 400, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 300],
+      [0, 400],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Chau Philomene One": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Chela One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Chelsea Market": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Chenla": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Cherish": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Cherry Cream Soda": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Cherry Swash": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Chewy": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Chicle": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Chilanka": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Chivo": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Chivo Mono": {
+    "fallbacks": ["monospace"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Chonburi": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Cinzel": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Cinzel Decorative": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700],
+      [0, 900]
+    ]
+  },
+  "Clicker Script": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Climate Crisis": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Coda": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 800]
+    ]
+  },
+  "Coda Caption": {
+    "fallbacks": ["sans-serif"],
+    "weights": [800],
+    "styles": [],
+    "variants": [[0, 800]]
+  },
+  "Codystar": {
+    "fallbacks": ["cursive"],
+    "weights": [300, 400],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400]
+    ]
+  },
+  "Coiny": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Combo": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Comfortaa": {
+    "fallbacks": ["cursive"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Comforter": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Comforter Brush": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Comic Neue": {
+    "fallbacks": ["cursive"],
+    "weights": [300, 400, 700],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Coming Soon": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Commissioner": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Concert One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Condiment": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Content": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Contrail One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Convergence": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Cookie": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Copse": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Corben": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Corinthia": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Cormorant": {
+    "fallbacks": ["serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700]
+    ]
+  },
+  "Cormorant Garamond": {
+    "fallbacks": ["serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Cormorant Infant": {
+    "fallbacks": ["serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Cormorant SC": {
+    "fallbacks": ["serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Cormorant Unicase": {
+    "fallbacks": ["serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Cormorant Upright": {
+    "fallbacks": ["serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Courgette": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Courier Prime": {
+    "fallbacks": ["monospace"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Cousine": {
+    "fallbacks": ["monospace"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Coustard": {
+    "fallbacks": ["serif"],
+    "weights": [400, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 900]
+    ]
+  },
+  "Covered By Your Grace": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Crafty Girls": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Creepster": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Crete Round": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Crimson Pro": {
+    "fallbacks": ["serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Crimson Text": {
+    "fallbacks": ["serif"],
+    "weights": [400, 600, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Croissant One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Crushed": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Cuprum": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700]
+    ]
+  },
+  "Cute Font": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Cutive": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Cutive Mono": {
+    "fallbacks": ["monospace"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Damion": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Dancing Script": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Dangrek": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Darker Grotesque": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "David Libre": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 700]
+    ]
+  },
+  "Dawning of a New Day": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Days One": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Dekko": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Dela Gothic One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Delicious Handrawn": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Delius": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Delius Swash Caps": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Delius Unicase": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Della Respira": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Denk One": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Devonshire": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Dhurjati": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Didact Gothic": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Diplomata": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Diplomata SC": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "DM Mono": {
+    "fallbacks": ["monospace"],
+    "weights": [300, 400, 500],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500]
+    ]
+  },
+  "DM Sans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "DM Serif Display": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "DM Serif Text": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Do Hyeon": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Dokdo": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Domine": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Donegal One": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Dongle": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Doppio One": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Dorsa": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Dosis": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "DotGothic16": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Dr Sugiyama": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Duru Sans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Dynalight": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "DynaPuff": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Eagle Lake": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "East Sea Dokdo": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Eater": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "EB Garamond": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 600, 700, 800],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800]
+    ]
+  },
+  "Economica": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Eczar": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Edu NSW ACT Foundation": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Edu QLD Beginner": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Edu SA Beginner": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Edu TAS Beginner": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Edu VIC WA NT Beginner": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "El Messiri": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Electrolize": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Elsie": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 900]
+    ]
+  },
+  "Elsie Swash Caps": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 900]
+    ]
+  },
+  "Emblema One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Emilys Candy": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Encode Sans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Encode Sans Condensed": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Encode Sans Expanded": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Encode Sans SC": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Encode Sans Semi Condensed": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Encode Sans Semi Expanded": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Engagement": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Englebert": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Enriqueta": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Ephesis": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Epilogue": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Erica One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Esteban": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Estonia": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Euphoria Script": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Ewert": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Exo": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Exo 2": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Expletus Sans": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700]
+    ]
+  },
+  "Explora": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Fahkwang": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Familjen Grotesk": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700]
+    ]
+  },
+  "Fanwood Text": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Farro": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 700]
+    ]
+  },
+  "Farsan": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Fascinate": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Fascinate Inline": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Faster One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Fasthand": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Fauna One": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Faustina": {
+    "fallbacks": ["serif"],
+    "weights": [300, 400, 500, 600, 700, 800],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800]
+    ]
+  },
+  "Federant": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Federo": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Felipa": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Fenix": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Festive": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Figtree": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Finger Paint": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Finlandica": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700]
+    ]
+  },
+  "Fira Code": {
+    "fallbacks": ["monospace"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Fira Mono": {
+    "fallbacks": ["monospace"],
+    "weights": [400, 500, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 700]
+    ]
+  },
+  "Fira Sans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 100],
+      [1, 100],
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700],
+      [0, 800],
+      [1, 800],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Fira Sans Condensed": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 100],
+      [1, 100],
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700],
+      [0, 800],
+      [1, 800],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Fira Sans Extra Condensed": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 100],
+      [1, 100],
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700],
+      [0, 800],
+      [1, 800],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Fjalla One": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Fjord One": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Flamenco": {
+    "fallbacks": ["cursive"],
+    "weights": [300, 400],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400]
+    ]
+  },
+  "Flavors": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Fleur De Leah": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Flow Block": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Flow Circular": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Flow Rounded": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Fondamento": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Fontdiner Swanky": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Forum": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Fragment Mono": {
+    "fallbacks": ["monospace"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Francois One": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Frank Ruhl Libre": {
+    "fallbacks": ["serif"],
+    "weights": [300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Fraunces": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Freckle Face": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Fredericka the Great": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Fredoka": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Freehand": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Fresca": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Frijole": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Fruktur": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Fugaz One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Fuggles": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Fuzzy Bubbles": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Gabriela": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Gaegu": {
+    "fallbacks": ["cursive"],
+    "weights": [300, 400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Gafata": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Gajraj One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Galada": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Galdeano": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Galindo": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Gamja Flower": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Gantari": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Gayathri": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Gelasio": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Gemunu Libre": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Genos": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Gentium Book Plus": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Gentium Plus": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Geo": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Georama": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Geostar": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Geostar Fill": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Germania One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "GFS Didot": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "GFS Neohellenic": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Gideon Roman": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Gidugu": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Gilda Display": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Girassol": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Give You Glory": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Glass Antiqua": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Glegoo": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Gloock": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Gloria Hallelujah": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Glory": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800]
+    ]
+  },
+  "Gluten": {
+    "fallbacks": ["cursive"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Goblin One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Gochi Hand": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Goldman": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Golos Text": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Gorditas": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Gothic A1": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Gotu": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Goudy Bookletter 1911": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Gowun Batang": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Gowun Dodum": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Graduate": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Grand Hotel": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Grandstander": {
+    "fallbacks": ["cursive"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Grape Nuts": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Gravitas One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Great Vibes": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Grechen Fuemen": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Grenze": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 100],
+      [1, 100],
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700],
+      [0, 800],
+      [1, 800],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Grenze Gotisch": {
+    "fallbacks": ["cursive"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Grey Qo": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Griffy": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Gruppo": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Gudea": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700]
+    ]
+  },
+  "Gugi": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Gulzar": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Gupter": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 700]
+    ]
+  },
+  "Gurajada": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Gwendolyn": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Habibi": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Hachi Maru Pop": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Hahmlet": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Halant": {
+    "fallbacks": ["serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Hammersmith One": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Hanalei": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Hanalei Fill": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Handlee": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Hanken Grotesk": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Hanuman": {
+    "fallbacks": ["serif"],
+    "weights": [100, 300, 400, 700, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 300],
+      [0, 400],
+      [0, 700],
+      [0, 900]
+    ]
+  },
+  "Happy Monkey": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Harmattan": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Headland One": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Heebo": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Henny Penny": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Hepta Slab": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Herr Von Muellerhoff": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Hi Melody": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Hina Mincho": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Hind": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Hind Guntur": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Hind Madurai": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Hind Siliguri": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Hind Vadodara": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Holtwood One SC": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Homemade Apple": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Homenaje": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Hubballi": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Hurricane": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Ibarra Real Nova": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700]
+    ]
+  },
+  "IBM Plex Mono": {
+    "fallbacks": ["monospace"],
+    "weights": [100, 200, 300, 400, 500, 600, 700],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 100],
+      [1, 100],
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "IBM Plex Sans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 100],
+      [1, 100],
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "IBM Plex Sans Arabic": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "IBM Plex Sans Condensed": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 100],
+      [1, 100],
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "IBM Plex Sans Devanagari": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "IBM Plex Sans Hebrew": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "IBM Plex Sans JP": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "IBM Plex Sans KR": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "IBM Plex Sans Thai": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "IBM Plex Sans Thai Looped": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "IBM Plex Serif": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 100],
+      [1, 100],
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Iceberg": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Iceland": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "IM Fell Double Pica": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "IM Fell Double Pica SC": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "IM Fell DW Pica": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "IM Fell DW Pica SC": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "IM Fell English": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "IM Fell English SC": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "IM Fell French Canon": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "IM Fell French Canon SC": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "IM Fell Great Primer": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "IM Fell Great Primer SC": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Imbue": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Imperial Script": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Imprima": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Inconsolata": {
+    "fallbacks": ["monospace"],
+    "weights": [200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Inder": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Indie Flower": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Ingrid Darling": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Inika": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Inknut Antiqua": {
+    "fallbacks": ["serif"],
+    "weights": [300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Inria Sans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 700],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Inria Serif": {
+    "fallbacks": ["serif"],
+    "weights": [300, 400, 700],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Inspiration": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Inter": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Inter Tight": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Irish Grover": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Island Moments": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Istok Web": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Italiana": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Italianno": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Itim": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Jacques Francois": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Jacques Francois Shadow": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Jaldi": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "JetBrains Mono": {
+    "fallbacks": ["monospace"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800]
+    ]
+  },
+  "Jim Nightshade": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Joan": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Jockey One": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Jolly Lodger": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Jomhuria": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Jomolhari": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Josefin Sans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700]
+    ]
+  },
+  "Josefin Slab": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700]
+    ]
+  },
+  "Jost": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Joti One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Jua": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Judson": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700]
+    ]
+  },
+  "Julee": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Julius Sans One": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Junge": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Jura": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Just Another Hand": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Just Me Again Down Here": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "K2D": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 100],
+      [1, 100],
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700],
+      [0, 800],
+      [1, 800]
+    ]
+  },
+  "Kadwa": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Kaisei Decol": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 700]
+    ]
+  },
+  "Kaisei HarunoUmi": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 700]
+    ]
+  },
+  "Kaisei Opti": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 700]
+    ]
+  },
+  "Kaisei Tokumin": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Kalam": {
+    "fallbacks": ["cursive"],
+    "weights": [300, 400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Kameron": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Kanit": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 100],
+      [1, 100],
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700],
+      [0, 800],
+      [1, 800],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Kantumruy Pro": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700]
+    ]
+  },
+  "Karantina": {
+    "fallbacks": ["cursive"],
+    "weights": [300, 400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Karla": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800]
+    ]
+  },
+  "Karma": {
+    "fallbacks": ["serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Katibeh": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Kaushan Script": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Kavivanar": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Kavoon": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Kdam Thmor Pro": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Keania One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Kelly Slab": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Kenia": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Khand": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Khmer": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Khula": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Kings": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Kirang Haerang": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Kite One": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Kiwi Maru": {
+    "fallbacks": ["serif"],
+    "weights": [300, 400, 500],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500]
+    ]
+  },
+  "Klee One": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 600],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 600]
+    ]
+  },
+  "Knewave": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Kodchasan": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Koh Santepheap": {
+    "fallbacks": ["cursive"],
+    "weights": [100, 300, 400, 700, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 300],
+      [0, 400],
+      [0, 700],
+      [0, 900]
+    ]
+  },
+  "KoHo": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Kolker Brush": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Kosugi": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Kosugi Maru": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Kotta One": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Koulen": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Kranky": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Kreon": {
+    "fallbacks": ["serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Kristi": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Krona One": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Krub": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Kufam": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Kulim Park": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 600, 700],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Kumar One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Kumar One Outline": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Kumbh Sans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Kurale": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "La Belle Aurore": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Labrada": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Lacquer": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Laila": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Lakki Reddy": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Lalezar": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Lancelot": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Langar": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Lateef": {
+    "fallbacks": ["serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Lato": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 300, 400, 700, 900],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 100],
+      [1, 100],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Lavishly Yours": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "League Gothic": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "League Script": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "League Spartan": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Leckerli One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Ledger": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Lekton": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700]
+    ]
+  },
+  "Lemon": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Lemonada": {
+    "fallbacks": ["cursive"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Lexend": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Lexend Deca": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Lexend Exa": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Lexend Giga": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Lexend Mega": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Lexend Peta": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Lexend Tera": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Lexend Zetta": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Libre Barcode 128": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Libre Barcode 128 Text": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Libre Barcode 39": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Libre Barcode 39 Extended": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Libre Barcode 39 Extended Text": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Libre Barcode 39 Text": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Libre Barcode EAN13 Text": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Libre Baskerville": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700]
+    ]
+  },
+  "Libre Bodoni": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700]
+    ]
+  },
+  "Libre Caslon Display": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Libre Caslon Text": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700]
+    ]
+  },
+  "Libre Franklin": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Licorice": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Life Savers": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Lilita One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Lily Script One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Limelight": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Linden Hill": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Literata": {
+    "fallbacks": ["serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Liu Jian Mao Cao": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Livvic": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 900],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 100],
+      [1, 100],
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Lobster": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Lobster Two": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Londrina Outline": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Londrina Shadow": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Londrina Sketch": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Londrina Solid": {
+    "fallbacks": ["cursive"],
+    "weights": [100, 300, 400, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 300],
+      [0, 400],
+      [0, 900]
+    ]
+  },
+  "Long Cang": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Lora": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700]
+    ]
+  },
+  "Love Light": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Love Ya Like A Sister": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Loved by the King": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Lovers Quarrel": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Luckiest Guy": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Lusitana": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Lustria": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Luxurious Roman": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Luxurious Script": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "M PLUS 1": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "M PLUS 1 Code": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "M PLUS 1p": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 300, 400, 500, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "M PLUS 2": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "M PLUS Code Latin": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "M PLUS Rounded 1c": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 300, 400, 500, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Ma Shan Zheng": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Macondo": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Macondo Swash Caps": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Mada": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 900]
+    ]
+  },
+  "Magra": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Maiden Orange": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Maitree": {
+    "fallbacks": ["serif"],
+    "weights": [200, 300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Major Mono Display": {
+    "fallbacks": ["monospace"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Mako": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Mali": {
+    "fallbacks": ["cursive"],
+    "weights": [200, 300, 400, 500, 600, 700],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Mallanna": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Mandali": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Manjari": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Manrope": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Mansalva": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Manuale": {
+    "fallbacks": ["serif"],
+    "weights": [300, 400, 500, 600, 700, 800],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800]
+    ]
+  },
+  "Marcellus": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Marcellus SC": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Marck Script": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Margarine": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Marhey": {
+    "fallbacks": ["cursive"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Markazi Text": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Marko One": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Marmelad": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Martel": {
+    "fallbacks": ["serif"],
+    "weights": [200, 300, 400, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Martel Sans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Martian Mono": {
+    "fallbacks": ["monospace"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Marvel": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Mate": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Mate SC": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Material Icons": {
+    "fallbacks": ["monospace"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Material Icons Outlined": {
+    "fallbacks": ["monospace"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Material Icons Round": {
+    "fallbacks": ["monospace"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Material Icons Sharp": {
+    "fallbacks": ["monospace"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Material Icons Two Tone": {
+    "fallbacks": ["monospace"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Material Symbols Outlined": {
+    "fallbacks": ["monospace"],
+    "weights": [100, 200, 300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Material Symbols Rounded": {
+    "fallbacks": ["monospace"],
+    "weights": [100, 200, 300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Material Symbols Sharp": {
+    "fallbacks": ["monospace"],
+    "weights": [100, 200, 300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Maven Pro": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "McLaren": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Mea Culpa": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Meddon": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "MedievalSharp": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Medula One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Meera Inimai": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Megrim": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Meie Script": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Meow Script": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Merienda": {
+    "fallbacks": ["cursive"],
+    "weights": [300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Merriweather": {
+    "fallbacks": ["serif"],
+    "weights": [300, 400, 700, 900],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Merriweather Sans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700, 800],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800]
+    ]
+  },
+  "Metal": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Metal Mania": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Metamorphous": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Metrophobic": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Michroma": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Milonga": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Miltonian": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Miltonian Tattoo": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Mina": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Mingzat": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Miniver": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Miriam Libre": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Mirza": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Miss Fajardose": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Mitr": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Mochiy Pop One": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Mochiy Pop P One": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Modak": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Modern Antiqua": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Mogra": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Mohave": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700]
+    ]
+  },
+  "Molengo": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Molle": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["italic"],
+    "variants": [[1, 400]]
+  },
+  "Monda": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Monofett": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Monoton": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Monsieur La Doulaise": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Montaga": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Montagu Slab": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "MonteCarlo": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Montez": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Montserrat": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Montserrat Alternates": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 100],
+      [1, 100],
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700],
+      [0, 800],
+      [1, 800],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Montserrat Subrayada": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Moo Lah Lah": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Moon Dance": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Moul": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Moulpali": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Mountains of Christmas": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Mouse Memoirs": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Mr Bedfort": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Mr Dafoe": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Mr De Haviland": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Mrs Saint Delafield": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Mrs Sheppards": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Ms Madi": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Mukta": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Mukta Mahee": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Mukta Malar": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Mukta Vaani": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Mulish": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Murecho": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "MuseoModerno": {
+    "fallbacks": ["cursive"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "My Soul": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Mynerve": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Mystery Quest": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Nabla": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Nanum Brush Script": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Nanum Gothic": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Nanum Gothic Coding": {
+    "fallbacks": ["monospace"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Nanum Myeongjo": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Nanum Pen Script": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Neonderthaw": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Nerko One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Neucha": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Neuton": {
+    "fallbacks": ["serif"],
+    "weights": [200, 300, 400, 700, 800],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "New Rocker": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "New Tegomin": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "News Cycle": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Newsreader": {
+    "fallbacks": ["serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800]
+    ]
+  },
+  "Niconne": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Niramit": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Nixie One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Nobile": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Nokora": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 300, 400, 700, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 300],
+      [0, 400],
+      [0, 700],
+      [0, 900]
+    ]
+  },
+  "Norican": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Nosifer": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Notable": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Nothing You Could Do": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noticia Text": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Noto Color Emoji": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Emoji": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Noto Kufi Arabic": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Music": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Naskh Arabic": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Noto Nastaliq Urdu": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Noto Rashi Hebrew": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Sans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 100],
+      [1, 100],
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700],
+      [0, 800],
+      [1, 800],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Noto Sans Adlam": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Noto Sans Adlam Unjoined": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Noto Sans Anatolian Hieroglyphs": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Arabic": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Armenian": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Avestan": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Balinese": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Noto Sans Bamum": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Noto Sans Bassa Vah": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Noto Sans Batak": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Bengali": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Bhaiksuki": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Brahmi": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Buginese": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Buhid": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Canadian Aboriginal": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Carian": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Caucasian Albanian": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Chakma": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Cham": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Cherokee": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Coptic": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Cuneiform": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Cypriot": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Deseret": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Devanagari": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Display": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Noto Sans Duployan": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Egyptian Hieroglyphs": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Elbasan": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Elymaic": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Ethiopic": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Georgian": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Glagolitic": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Gothic": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Grantha": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Gujarati": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Gunjala Gondi": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Gurmukhi": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Hanifi Rohingya": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Noto Sans Hanunoo": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Hatran": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Hebrew": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Sans HK": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 300, 400, 500, 700, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 700],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Imperial Aramaic": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Indic Siyaq Numbers": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Inscriptional Pahlavi": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Inscriptional Parthian": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Javanese": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Noto Sans JP": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 300, 400, 500, 700, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 700],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Kaithi": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Kannada": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Kayah Li": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Noto Sans Kharoshthi": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Khmer": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Khojki": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Khudawadi": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans KR": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 300, 400, 500, 700, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 700],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Lao": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Lao Looped": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Lepcha": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Limbu": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Linear A": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Linear B": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Lisu": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Noto Sans Lycian": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Lydian": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Mahajani": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Malayalam": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Mandaic": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Manichaean": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Marchen": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Masaram Gondi": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Math": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Mayan Numerals": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Medefaidrin": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Noto Sans Meetei Mayek": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Mende Kikakui": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Meroitic": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Miao": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Modi": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Mongolian": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Mono": {
+    "fallbacks": ["monospace"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Mro": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Multani": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Myanmar": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Nabataean": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans New Tai Lue": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Noto Sans Newa": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans NKo": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Nushu": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Ogham": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Ol Chiki": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Noto Sans Old Hungarian": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Old Italic": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Old North Arabian": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Old Permic": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Old Persian": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Old Sogdian": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Old South Arabian": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Old Turkic": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Oriya": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Osage": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Osmanya": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Pahawh Hmong": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Palmyrene": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Pau Cin Hau": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Phags Pa": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Phoenician": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Psalter Pahlavi": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Rejang": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Runic": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Samaritan": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Saurashtra": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans SC": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 300, 400, 500, 700, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 700],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Sharada": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Shavian": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Siddham": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans SignWriting": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Sinhala": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Sogdian": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Sora Sompeng": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Noto Sans Soyombo": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Sundanese": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Noto Sans Syloti Nagri": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Symbols": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Symbols 2": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Syriac": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 400, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 400],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Tagalog": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Tagbanwa": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Tai Le": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Tai Tham": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Noto Sans Tai Viet": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Takri": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Tamil": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Tamil Supplement": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Tangsa": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Noto Sans TC": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 300, 400, 500, 700, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 700],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Telugu": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Thaana": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Thai": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Thai Looped": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Sans Tifinagh": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Tirhuta": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Ugaritic": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Vai": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Wancho": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Warang Citi": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Yi": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Sans Zanabazar Square": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Serif": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Noto Serif Ahom": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Serif Armenian": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Serif Balinese": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Serif Bengali": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Serif Devanagari": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Serif Display": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Noto Serif Dogra": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Serif Ethiopic": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Serif Georgian": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Serif Grantha": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Serif Gujarati": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Serif Gurmukhi": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Serif Hebrew": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Serif HK": {
+    "fallbacks": ["serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Serif JP": {
+    "fallbacks": ["serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 900]
+    ]
+  },
+  "Noto Serif Kannada": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Serif Khmer": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Serif Khojki": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Noto Serif KR": {
+    "fallbacks": ["serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 900]
+    ]
+  },
+  "Noto Serif Lao": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Serif Malayalam": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Serif Myanmar": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Serif NP Hmong": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Noto Serif Oriya": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Noto Serif SC": {
+    "fallbacks": ["serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 900]
+    ]
+  },
+  "Noto Serif Sinhala": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Serif Tamil": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Noto Serif Tangut": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Noto Serif TC": {
+    "fallbacks": ["serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 900]
+    ]
+  },
+  "Noto Serif Telugu": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Serif Thai": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Serif Tibetan": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Noto Serif Toto": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Noto Serif Yezidi": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Noto Traditional Nushu": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Nova Cut": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Nova Flat": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Nova Mono": {
+    "fallbacks": ["monospace"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Nova Oval": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Nova Round": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Nova Script": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Nova Slim": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Nova Square": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "NTR": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Numans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Nunito": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Nunito Sans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 600, 700, 800, 900],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700],
+      [0, 800],
+      [1, 800],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Nuosu SIL": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Odibee Sans": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Odor Mean Chey": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Offside": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Oi": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Old Standard TT": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700]
+    ]
+  },
+  "Oldenburg": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Ole": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Oleo Script": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Oleo Script Swash Caps": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Oooh Baby": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Open Sans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700, 800],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800]
+    ]
+  },
+  "Oranienbaum": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Orbitron": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Oregano": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Orelega One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Orienta": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Original Surfer": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Oswald": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Outfit": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Over the Rainbow": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Overlock": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Overlock SC": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Overpass": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Overpass Mono": {
+    "fallbacks": ["monospace"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Ovo": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Oxanium": {
+    "fallbacks": ["cursive"],
+    "weights": [200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Oxygen": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Oxygen Mono": {
+    "fallbacks": ["monospace"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Pacifico": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Padauk": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Padyakke Expanded One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Palanquin": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Palanquin Dark": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Pangolin": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Paprika": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Parisienne": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Passero One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Passion One": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700],
+      [0, 900]
+    ]
+  },
+  "Passions Conflict": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Pathway Gothic One": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Patrick Hand": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Patrick Hand SC": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Pattaya": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Patua One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Pavanam": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Paytone One": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Peddana": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Peralta": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Permanent Marker": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Petemoss": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Petit Formal Script": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Petrona": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Philosopher": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Phudu": {
+    "fallbacks": ["cursive"],
+    "weights": [300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Piazzolla": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Piedra": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Pinyon Script": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Pirata One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Plaster": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Play": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Playball": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Playfair Display": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Playfair Display SC": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Plus Jakarta Sans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800]
+    ]
+  },
+  "Podkova": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Poiret One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Poller One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Poly": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Pompiere": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Pontano Sans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Poor Story": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Poppins": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 100],
+      [1, 100],
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700],
+      [0, 800],
+      [1, 800],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Port Lligat Sans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Port Lligat Slab": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Potta One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Pragati Narrow": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Praise": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Prata": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Preahvihear": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Press Start 2P": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Pridi": {
+    "fallbacks": ["serif"],
+    "weights": [200, 300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Princess Sofia": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Prociono": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Prompt": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 100],
+      [1, 100],
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700],
+      [0, 800],
+      [1, 800],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Prosto One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Proza Libre": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700, 800],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700],
+      [0, 800],
+      [1, 800]
+    ]
+  },
+  "PT Mono": {
+    "fallbacks": ["monospace"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "PT Sans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "PT Sans Caption": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "PT Sans Narrow": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "PT Serif": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "PT Serif Caption": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Public Sans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Puppies Play": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Puritan": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Purple Purse": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Qahiri": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Quando": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Quantico": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Quattrocento": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Quattrocento Sans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Questrial": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Quicksand": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Quintessential": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Qwigley": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Qwitcher Grypen": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Racing Sans One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Radio Canada": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700]
+    ]
+  },
+  "Radley": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Rajdhani": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Rakkas": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Raleway": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Raleway Dots": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Ramabhadra": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Ramaraja": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Rambla": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Rammetto One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Rampart One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Ranchers": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Rancho": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Ranga": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Rasa": {
+    "fallbacks": ["serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700]
+    ]
+  },
+  "Rationale": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Ravi Prakash": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Readex Pro": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Recursive": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Red Hat Display": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Red Hat Mono": {
+    "fallbacks": ["monospace"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700]
+    ]
+  },
+  "Red Hat Text": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700]
+    ]
+  },
+  "Red Rose": {
+    "fallbacks": ["cursive"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Redacted": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Redacted Script": {
+    "fallbacks": ["cursive"],
+    "weights": [300, 400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Redressed": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Reem Kufi": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Reem Kufi Fun": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Reem Kufi Ink": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Reenie Beanie": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Reggae One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Revalia": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Rhodium Libre": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Ribeye": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Ribeye Marrow": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Righteous": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Risque": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Road Rage": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Roboto": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 300, 400, 500, 700, 900],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 100],
+      [1, 100],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 700],
+      [1, 700],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Roboto Condensed": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 700],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Roboto Flex": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Roboto Mono": {
+    "fallbacks": ["monospace"],
+    "weights": [100, 200, 300, 400, 500, 600, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700]
+    ]
+  },
+  "Roboto Serif": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Roboto Slab": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Rochester": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Rock Salt": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "RocknRoll One": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Rokkitt": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Romanesco": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Ropa Sans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Rosario": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700]
+    ]
+  },
+  "Rosarivo": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Rouge Script": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Rowdies": {
+    "fallbacks": ["cursive"],
+    "weights": [300, 400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Rozha One": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Rubik": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Rubik 80s Fade": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Rubik Beastly": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Rubik Bubbles": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Rubik Burned": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Rubik Dirt": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Rubik Distressed": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Rubik Gemstones": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Rubik Glitch": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Rubik Iso": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Rubik Marker Hatch": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Rubik Maze": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Rubik Microbe": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Rubik Mono One": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Rubik Moonrocks": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Rubik Puddles": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Rubik Spray Paint": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Rubik Storm": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Rubik Vinyl": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Rubik Wet Paint": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Ruda": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Rufina": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Ruge Boogie": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Ruluko": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Rum Raisin": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Ruslan Display": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Russo One": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Ruthie": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Rye": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Sacramento": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Sahitya": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Sail": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Saira": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Saira Condensed": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Saira Extra Condensed": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Saira Semi Condensed": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Saira Stencil One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Salsa": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Sanchez": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Sancreek": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Sansita": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700],
+      [0, 800],
+      [1, 800],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Sansita Swashed": {
+    "fallbacks": ["cursive"],
+    "weights": [300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Sarabun": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 100],
+      [1, 100],
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700],
+      [0, 800],
+      [1, 800]
+    ]
+  },
+  "Sarala": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Sarina": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Sarpanch": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Sassy Frass": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Satisfy": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Sawarabi Gothic": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Sawarabi Mincho": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Scada": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Scheherazade New": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Schoolbell": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Scope One": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Seaweed Script": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Secular One": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Sedgwick Ave": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Sedgwick Ave Display": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Sen": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Send Flowers": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Sevillana": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Seymour One": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Shadows Into Light": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Shadows Into Light Two": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Shalimar": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Shantell Sans": {
+    "fallbacks": ["cursive"],
+    "weights": [300, 400, 500, 600, 700, 800],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800]
+    ]
+  },
+  "Shanti": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Share": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Share Tech": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Share Tech Mono": {
+    "fallbacks": ["monospace"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Shippori Antique": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Shippori Antique B1": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Shippori Mincho": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Shippori Mincho B1": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Shojumaru": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Short Stack": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Shrikhand": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Siemreap": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Sigmar One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Signika": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Signika Negative": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Silkscreen": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Simonetta": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Single Day": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Sintony": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Sirin Stencil": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Six Caps": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Skranji": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Slabo 13px": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Slabo 27px": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Slackey": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Smokum": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Smooch": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Smooch Sans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Smythe": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Sniglet": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 800]
+    ]
+  },
+  "Snippet": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Snowburst One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Sofadi One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Sofia": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Sofia Sans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Sofia Sans Condensed": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Sofia Sans Extra Condensed": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Sofia Sans Semi Condensed": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Solitreo": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Solway": {
+    "fallbacks": ["serif"],
+    "weights": [300, 400, 500, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Song Myung": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Sono": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Sonsie One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Sora": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Sorts Mill Goudy": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Source Code Pro": {
+    "fallbacks": ["monospace"],
+    "weights": [200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Source Sans 3": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Source Sans Pro": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 600, 700, 900],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Source Serif 4": {
+    "fallbacks": ["serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Source Serif Pro": {
+    "fallbacks": ["serif"],
+    "weights": [200, 300, 400, 600, 700, 900],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Space Grotesk": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Space Mono": {
+    "fallbacks": ["monospace"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Special Elite": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Spectral": {
+    "fallbacks": ["serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 800],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700],
+      [0, 800],
+      [1, 800]
+    ]
+  },
+  "Spectral SC": {
+    "fallbacks": ["serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 800],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700],
+      [0, 800],
+      [1, 800]
+    ]
+  },
+  "Spicy Rice": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Spinnaker": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Spirax": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Splash": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Spline Sans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Spline Sans Mono": {
+    "fallbacks": ["monospace"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700]
+    ]
+  },
+  "Squada One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Square Peg": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Sree Krushnadevaraya": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Sriracha": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Srisakdi": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Staatliches": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Stalemate": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Stalinist One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Stardos Stencil": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Stick": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Stick No Bills": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Stint Ultra Condensed": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Stint Ultra Expanded": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "STIX Two Text": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 600, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700]
+    ]
+  },
+  "Stoke": {
+    "fallbacks": ["serif"],
+    "weights": [300, 400],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400]
+    ]
+  },
+  "Strait": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Style Script": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Stylish": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Sue Ellen Francisco": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Suez One": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Sulphur Point": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Sumana": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Sunflower": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 500, 700],
+    "styles": [],
+    "variants": [
+      [0, 300],
+      [0, 500],
+      [0, 700]
+    ]
+  },
+  "Sunshiney": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Supermercado One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Sura": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Suranna": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Suravaram": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Suwannaphum": {
+    "fallbacks": ["serif"],
+    "weights": [100, 300, 400, 700, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 300],
+      [0, 400],
+      [0, 700],
+      [0, 900]
+    ]
+  },
+  "Swanky and Moo Moo": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Syncopate": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Syne": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Syne Mono": {
+    "fallbacks": ["monospace"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Syne Tactile": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Tai Heritage Pro": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Tajawal": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Tangerine": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Tapestry": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Taprom": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Tauri": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Taviraj": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 100],
+      [1, 100],
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700],
+      [0, 800],
+      [1, 800],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Teko": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Telex": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Tenali Ramakrishna": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Tenor Sans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Text Me One": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Texturina": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Thasadith": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "The Girl Next Door": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "The Nautigal": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Tienne": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700],
+      [0, 900]
+    ]
+  },
+  "Tillana": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Timmana": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Tinos": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Tiro Bangla": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Tiro Devanagari Hindi": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Tiro Devanagari Marathi": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Tiro Devanagari Sanskrit": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Tiro Gurmukhi": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Tiro Kannada": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Tiro Tamil": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Tiro Telugu": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Titan One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Titillium Web": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 600, 700, 900],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700],
+      [0, 900]
+    ]
+  },
+  "Tomorrow": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 100],
+      [1, 100],
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700],
+      [0, 800],
+      [1, 800],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Tourney": {
+    "fallbacks": ["cursive"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Trade Winds": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Train One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Trirong": {
+    "fallbacks": ["serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 100],
+      [1, 100],
+      [0, 200],
+      [1, 200],
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700],
+      [0, 800],
+      [1, 800],
+      [0, 900],
+      [1, 900]
+    ]
+  },
+  "Trispace": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Trocchi": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Trochut": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700]
+    ]
+  },
+  "Truculenta": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Trykker": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Tulpen One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Turret Road": {
+    "fallbacks": ["cursive"],
+    "weights": [200, 300, 400, 500, 700, 800],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 700],
+      [0, 800]
+    ]
+  },
+  "Twinkle Star": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Ubuntu": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 700],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Ubuntu Condensed": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Ubuntu Mono": {
+    "fallbacks": ["monospace"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Uchen": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Ultra": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Unbounded": {
+    "fallbacks": ["cursive"],
+    "weights": [200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Uncial Antiqua": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Underdog": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Unica One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "UnifrakturCook": {
+    "fallbacks": ["cursive"],
+    "weights": [700],
+    "styles": [],
+    "variants": [[0, 700]]
+  },
+  "UnifrakturMaguntia": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Unkempt": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  },
+  "Unlock": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Unna": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Updock": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Urbanist": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Vampiro One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Varela": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Varela Round": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Varta": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Vast Shadow": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Vazirmatn": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900]
+    ]
+  },
+  "Vesper Libre": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 700, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 700],
+      [0, 900]
+    ]
+  },
+  "Viaoda Libre": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Vibes": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Vibur": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Vidaloka": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Viga": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Voces": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Volkhov": {
+    "fallbacks": ["serif"],
+    "weights": [400, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Vollkorn": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Vollkorn SC": {
+    "fallbacks": ["serif"],
+    "weights": [400, 600, 700, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 600],
+      [0, 700],
+      [0, 900]
+    ]
+  },
+  "Voltaire": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "VT323": {
+    "fallbacks": ["monospace"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Vujahday Script": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Waiting for the Sunrise": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Wallpoet": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Walter Turncoat": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Warnes": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Water Brush": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Waterfall": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Wellfleet": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Wendy One": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Whisper": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "WindSong": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 500],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500]
+    ]
+  },
+  "Wire One": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Work Sans": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 100],
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 800],
+      [0, 900],
+      [1, 100],
+      [1, 200],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700],
+      [1, 800],
+      [1, 900]
+    ]
+  },
+  "Xanh Mono": {
+    "fallbacks": ["monospace"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Yaldevi": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Yanone Kaffeesatz": {
+    "fallbacks": ["sans-serif"],
+    "weights": [200, 300, 400, 500, 600, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 200],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700]
+    ]
+  },
+  "Yantramanav": {
+    "fallbacks": ["sans-serif"],
+    "weights": [100, 300, 400, 500, 700, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 100],
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 700],
+      [0, 900]
+    ]
+  },
+  "Yatra One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Yellowtail": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Yeon Sung": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Yeseva One": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Yesteryear": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Yomogi": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Yrsa": {
+    "fallbacks": ["serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [1, 300],
+      [1, 400],
+      [1, 500],
+      [1, 600],
+      [1, 700]
+    ]
+  },
+  "Yuji Boku": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Yuji Mai": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Yuji Syuku": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Yusei Magic": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "ZCOOL KuaiLe": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "ZCOOL QingKe HuangYou": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "ZCOOL XiaoWei": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Zen Antique": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Zen Antique Soft": {
+    "fallbacks": ["serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Zen Dots": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Zen Kaku Gothic Antique": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 700, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 700],
+      [0, 900]
+    ]
+  },
+  "Zen Kaku Gothic New": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 700, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 700],
+      [0, 900]
+    ]
+  },
+  "Zen Kurenaido": {
+    "fallbacks": ["sans-serif"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Zen Loop": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular", "italic"],
+    "variants": [
+      [0, 400],
+      [1, 400]
+    ]
+  },
+  "Zen Maru Gothic": {
+    "fallbacks": ["sans-serif"],
+    "weights": [300, 400, 500, 700, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 300],
+      [0, 400],
+      [0, 500],
+      [0, 700],
+      [0, 900]
+    ]
+  },
+  "Zen Old Mincho": {
+    "fallbacks": ["serif"],
+    "weights": [400, 500, 600, 700, 900],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 500],
+      [0, 600],
+      [0, 700],
+      [0, 900]
+    ]
+  },
+  "Zen Tokyo Zoo": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Zeyada": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Zhi Mang Xing": {
+    "fallbacks": ["cursive"],
+    "weights": [400],
+    "styles": ["regular"],
+    "variants": [[0, 400]]
+  },
+  "Zilla Slab": {
+    "fallbacks": ["serif"],
+    "weights": [300, 400, 500, 600, 700],
+    "styles": ["italic", "regular"],
+    "variants": [
+      [0, 300],
+      [1, 300],
+      [0, 400],
+      [1, 400],
+      [0, 500],
+      [1, 500],
+      [0, 600],
+      [1, 600],
+      [0, 700],
+      [1, 700]
+    ]
+  },
+  "Zilla Slab Highlight": {
+    "fallbacks": ["cursive"],
+    "weights": [400, 700],
+    "styles": ["regular"],
+    "variants": [
+      [0, 400],
+      [0, 700]
+    ]
+  }
+}

--- a/packages/support-fonts/services/fonts.google.com/index.ts
+++ b/packages/support-fonts/services/fonts.google.com/index.ts
@@ -1,12 +1,15 @@
 import fonts from "./fonts.json";
 import { constructURL } from "./utils";
 
-interface GoogleFontMeta {
-  family: string;
+interface MinimalGoogleFontMeta {
   fallbacks: string[];
   weights: number[];
   styles: string[];
   variants: [number, number][];
+}
+
+interface GoogleFontMeta extends MinimalGoogleFontMeta {
+  family: string;
   service: "fonts.google.com";
   urls: {
     [request: string]: string;
@@ -20,18 +23,22 @@ interface GoogleFontMeta {
  * @returns
  */
 export function googlefont(family: string): GoogleFontMeta | false {
-  const found = fonts[family];
+  const found = fonts[family] as MinimalGoogleFontMeta;
   if (found) {
     return {
       ...found,
       family,
       service: "fonts.google.com",
       urls: {
-        "*": {}, // TODO:
-        //   // constructURL({
-        //   // families: [family],
-        //   // , found.styles, found.weights
-        // }),
+        "*":
+          constructURL({
+            families: {
+              [family]: {
+                wght: found.weights,
+                // TODO: add styles and variants support
+              },
+            },
+          }) || "",
       },
     };
   }

--- a/packages/support-fonts/services/fonts.google.com/index.ts
+++ b/packages/support-fonts/services/fonts.google.com/index.ts
@@ -1,0 +1,27 @@
+import fonts from "./fonts.json";
+import { constructURL } from "./utils";
+
+interface GoogleFontMeta {
+  family: string;
+  fallbacks: string[];
+  weights: number[];
+  styles: string[];
+  variants: [number, number][];
+}
+
+/**
+ * Get the google font with the given family name
+ * If the font is not found, it will return undefined
+ * @param family
+ * @returns
+ */
+export function googlefont(family: string): GoogleFontMeta | false {
+  const found = fonts[family];
+  if (found) {
+    return {
+      ...found,
+      family,
+    };
+  }
+  return false;
+}

--- a/packages/support-fonts/services/fonts.google.com/index.ts
+++ b/packages/support-fonts/services/fonts.google.com/index.ts
@@ -7,6 +7,10 @@ interface GoogleFontMeta {
   weights: number[];
   styles: string[];
   variants: [number, number][];
+  service: "fonts.google.com";
+  urls: {
+    [request: string]: string;
+  };
 }
 
 /**
@@ -21,6 +25,14 @@ export function googlefont(family: string): GoogleFontMeta | false {
     return {
       ...found,
       family,
+      service: "fonts.google.com",
+      urls: {
+        "*": {}, // TODO:
+        //   // constructURL({
+        //   // families: [family],
+        //   // , found.styles, found.weights
+        // }),
+      },
     };
   }
   return false;

--- a/packages/support-fonts/services/fonts.google.com/utils/LICENSE
+++ b/packages/support-fonts/services/fonts.google.com/utils/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Datalogix, Grida Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/support-fonts/services/fonts.google.com/utils/README.md
+++ b/packages/support-fonts/services/fonts.google.com/utils/README.md
@@ -1,0 +1,4 @@
+# google fonts utils - forked from https://github.com/majodev/google-webfonts-helper
+
+- [License](https://github.com/majodev/google-webfonts-helper/blob/master/LICENSE.txt)
+- [Original Author](https://github.com/majodev)

--- a/packages/support-fonts/services/fonts.google.com/utils/index.ts
+++ b/packages/support-fonts/services/fonts.google.com/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./url";

--- a/packages/support-fonts/services/fonts.google.com/utils/url.ts
+++ b/packages/support-fonts/services/fonts.google.com/utils/url.ts
@@ -1,0 +1,209 @@
+import { QueryObject, resolveURL, withQuery, withHttps } from "ufo";
+
+export function constructURL({
+  families,
+  display,
+  subsets,
+  text,
+}: GoogleFonts = {}): string | false {
+  const subset = (Array.isArray(subsets) ? subsets : [subsets]).filter(Boolean);
+  const prefix = subset.length > 0 ? "css" : "css2";
+  const family = convertFamiliesToArray(families ?? {}, prefix.endsWith("2"));
+
+  if (family.length < 1) {
+    return false;
+  }
+
+  const query: QueryObject = {
+    family,
+  };
+
+  if (display && isValidDisplay(display)) {
+    query.display = display;
+  }
+
+  if (subset.length > 0) {
+    query.subset = subset.join(",");
+  }
+
+  if (text) {
+    query.text = text;
+  }
+
+  return withHttps(withQuery(resolveURL(GOOGLE_FONTS_DOMAIN, prefix), query));
+}
+
+function convertFamiliesToArray(families: Families, v2 = true): string[] {
+  const result: string[] = [];
+
+  // v1
+  if (!v2) {
+    Object.entries(families).forEach(([name, values]) => {
+      if (!name) {
+        return;
+      }
+
+      name = parseFamilyName(name);
+
+      if (
+        (Array.isArray(values) && values.length > 0) ||
+        values === true ||
+        values === 400
+      ) {
+        result.push(name);
+        return;
+      }
+
+      if (values === 700) {
+        result.push(`${name}:bold`);
+        return;
+      }
+
+      if (Object.keys(values).length > 0) {
+        const styles: string[] = [];
+
+        Object.entries(values)
+          .sort(([styleA], [styleB]) => styleA.localeCompare(styleB))
+          .forEach(([style, weight]) => {
+            const styleParsed = parseStyle(style);
+
+            if (
+              styleParsed === "ital" &&
+              (weight === 700 ||
+                (Array.isArray(weight) && weight.includes(700)))
+            ) {
+              styles.push("bolditalic");
+
+              if (Array.isArray(weight) && weight.includes(400)) {
+                styles.push(styleParsed);
+              }
+            } else if (
+              styleParsed === "wght" &&
+              (weight === 700 ||
+                (Array.isArray(weight) && weight.includes(700)))
+            ) {
+              styles.push("bold");
+
+              if (Array.isArray(weight) && weight.includes(400)) {
+                styles.push(styleParsed);
+              }
+            } else if (weight !== false) {
+              styles.push(styleParsed);
+            }
+          });
+
+        const stylesSortered = styles
+          .sort(([styleA], [styleB]) => styleA.localeCompare(styleB))
+          .reverse()
+          .join(",");
+
+        if (stylesSortered === "wght") {
+          result.push(name);
+          return;
+        }
+
+        result.push(`${name}:${stylesSortered}`);
+      }
+    });
+
+    return result.length ? [result.join("|")] : result;
+  }
+
+  // v2
+  if (v2) {
+    Object.entries(families).forEach(([name, values]) => {
+      if (!name) {
+        return;
+      }
+
+      name = parseFamilyName(name);
+
+      if (Array.isArray(values) && values.length > 0) {
+        result.push(`${name}:wght@${values.join(";")}`);
+        return;
+      }
+
+      if (Object.keys(values).length > 0) {
+        const styles: string[] = [];
+        const weights: string[] = [];
+
+        Object.entries(values)
+          .sort(([styleA], [styleB]) => styleA.localeCompare(styleB))
+          .forEach(([style, weight]) => {
+            const styleParsed = parseStyle(style);
+            styles.push(styleParsed);
+
+            (Array.isArray(weight) ? weight : [weight]).forEach(
+              (value: string | number) => {
+                if (
+                  Object.keys(values).length === 1 &&
+                  styleParsed === "wght"
+                ) {
+                  weights.push(String(value));
+                } else {
+                  const index = styleParsed === "wght" ? 0 : 1;
+                  weights.push(`${index},${value}`);
+                }
+              }
+            );
+          });
+
+        if (!styles.includes("wght")) {
+          styles.push("wght");
+        }
+
+        const weightsSortered = weights
+          .sort(([weightA], [weightB]) => weightA.localeCompare(weightB))
+          .join(";");
+
+        result.push(`${name}:${styles.join(",")}@${weightsSortered}`);
+        return;
+      }
+
+      if (values) {
+        result.push(name);
+      }
+    });
+  }
+
+  return result;
+}
+
+export const GOOGLE_FONTS_DOMAIN = "fonts.googleapis.com";
+
+export function isValidDisplay(display: string): boolean {
+  return ["auto", "block", "swap", "fallback", "optional"].includes(display);
+}
+
+export function parseStyle(style: string): string {
+  const _style = style.toLowerCase();
+
+  if (["wght", "regular", "normal"].includes(_style)) {
+    return "wght";
+  }
+
+  if (["i", "italic", "ital"].includes(_style)) {
+    return "ital";
+  }
+
+  return _style;
+}
+
+export function parseFamilyName(name: string) {
+  return decodeURIComponent(name).replace(/\+/g, " ");
+}
+
+interface FamilyStyles {
+  [style: string]: boolean | number | number[];
+}
+
+interface Families {
+  [family: string]: boolean | number | number[] | FamilyStyles;
+}
+
+interface GoogleFonts {
+  families?: Families;
+  display?: string;
+  subsets?: string[] | string;
+  text?: string;
+}

--- a/packages/support-fonts/services/system/README.md
+++ b/packages/support-fonts/services/system/README.md
@@ -1,0 +1,7 @@
+# Safe system fonts utilities
+
+## References
+
+## About the [`font.json`](./fonts.json)
+
+The font.json is a manipulated version of the [@googleforcreators/fonts](https://github.com/GoogleForCreators/web-stories-wp/blob/main/packages/fonts/src/fonts.json) containing only minified system fonts info.

--- a/packages/support-fonts/services/system/fonts.json
+++ b/packages/support-fonts/services/system/fonts.json
@@ -1,0 +1,93 @@
+{
+  "Arial": {
+    "fallbacks": ["Helvetica Neue", "Helvetica", "sans-serif"]
+  },
+  "Arial Black": {
+    "fallbacks": ["Arial Black", "Arial Bold", "Gadget", "sans-serif"]
+  },
+  "Arial Narrow": {
+    "fallbacks": ["Arial", "sans-serif"]
+  },
+  "Baskerville": {
+    "fallbacks": [
+      "Baskerville Old Face",
+      "Hoefler Text",
+      "Garamond",
+      "Times New Roman",
+      "serif"
+    ]
+  },
+  "Brush Script MT": {
+    "fallbacks": ["cursive"]
+  },
+  "Century Gothic": {
+    "fallbacks": ["CenturyGothic", "AppleGothic", "sans-serif"]
+  },
+  "Copperplate": {
+    "fallbacks": ["Copperplate Gothic Light", "fantasy"]
+  },
+  "Courier New": {
+    "fallbacks": [
+      "Courier",
+      "Lucida Sans Typewriter",
+      "Lucida Typewriter",
+      "monospace"
+    ]
+  },
+  "Garamond": {
+    "fallbacks": [
+      "Baskerville",
+      "Baskerville Old Face",
+      "Hoefler Text",
+      "Times New Roman",
+      "serif"
+    ]
+  },
+  "Georgia": {
+    "fallbacks": ["Times", "Times New Roman", "serif"]
+  },
+  "Gill Sans": {
+    "fallbacks": ["Gill Sans MT", "Calibri", "sans-serif"]
+  },
+  "Lucida Bright": {
+    "fallbacks": ["Georgia", "serif"]
+  },
+  "Lucida Sans Typewriter": {
+    "fallbacks": [
+      "Lucida Console",
+      "monaco",
+      "Bitstream Vera Sans Mono",
+      "monospace"
+    ]
+  },
+  "Palatino": {
+    "fallbacks": [
+      "Palatino Linotype",
+      "Palatino LT STD",
+      "Book Antiqua",
+      "Georgia",
+      "serif"
+    ]
+  },
+  "Papyrus": {
+    "fallbacks": ["fantasy"]
+  },
+  "Tahoma": {
+    "fallbacks": ["Verdana", "Segoe", "sans-serif"]
+  },
+  "Times New Roman": {
+    "fallbacks": ["Times New Roman", "Times", "Baskerville", "Georgia", "serif"]
+  },
+  "Trebuchet MS": {
+    "fallbacks": [
+      "Lucida Grande",
+      "Lucida Sans Unicode",
+      "Lucida Sans",
+      "Tahoma",
+      "sans-serif"
+    ]
+  },
+  "Verdana": {
+    "fallbacks": ["Geneva", "sans-serif"]
+  }
+}

--- a/packages/support-fonts/services/system/index.ts
+++ b/packages/support-fonts/services/system/index.ts
@@ -1,0 +1,23 @@
+import fonts from "./fonts.json";
+
+interface SystemFontMeta {
+  family: string;
+  fallbacks: string[];
+}
+
+/**
+ * Get the google font with the given family name
+ * If the font is not found, it will return undefined
+ * @param family
+ * @returns
+ */
+export function systemfont(family: string): SystemFontMeta | false {
+  const found = fonts[family];
+  if (found) {
+    return {
+      ...found,
+      family,
+    };
+  }
+  return false;
+}

--- a/packages/support-fonts/services/system/index.ts
+++ b/packages/support-fonts/services/system/index.ts
@@ -4,6 +4,7 @@ interface SystemFontMeta {
   family: string;
   fallbacks: string[];
   service: "system";
+  urls: {};
 }
 
 /**
@@ -19,6 +20,7 @@ export function systemfont(family: string): SystemFontMeta | false {
       ...found,
       family,
       service: "system",
+      urls: {},
     };
   }
   return false;

--- a/packages/support-fonts/services/system/index.ts
+++ b/packages/support-fonts/services/system/index.ts
@@ -3,6 +3,7 @@ import fonts from "./fonts.json";
 interface SystemFontMeta {
   family: string;
   fallbacks: string[];
+  service: "system";
 }
 
 /**
@@ -17,6 +18,7 @@ export function systemfont(family: string): SystemFontMeta | false {
     return {
       ...found,
       family,
+      service: "system",
     };
   }
   return false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1467,10 +1467,10 @@
   resolved "https://registry.npmjs.org/@design-sdk/figma-auth-store/-/figma-auth-store-0.0.43.tgz"
   integrity sha512-5VF1EijfZwzOMq+r4ipQ0aDRk/JSUHOjg9cI7oaD+K+sw2YIjgxSBE05/tvncZhOpmFvDHSHTISYJfUsEWfSUQ==
 
-"@design-sdk/figma-core@^0.0.43":
-  version "0.0.43"
-  resolved "https://registry.yarnpkg.com/@design-sdk/figma-core/-/figma-core-0.0.43.tgz#0d19d014daf398ed39046bfd4e7f3d2b78842943"
-  integrity sha512-7WQ29f4hUOxu4Mu8ZyqbBI5F4DsRJbIjGIcZAUmn7O9/SRR00upTYrl2hdlEnKdE0ImHTYqfISgxjkoYEQgZaQ==
+"@design-sdk/figma-core@^0.0.25":
+  version "0.0.25"
+  resolved "https://registry.yarnpkg.com/@design-sdk/figma-core/-/figma-core-0.0.25.tgz#7fa28cc7d6e45cd713c5f268d42e4dd4f2b41590"
+  integrity sha512-6OF7eUbDOlR4/BFtd2FRyDvvUf777OGNbVbNScUOv3Fk/kUXBzMTXX6ZdoRlTx887v/vo3+Lh0D31SG1sm80aA==
 
 "@design-sdk/figma-node-conversion@^0.0.43":
   version "0.0.43"
@@ -1493,13 +1493,13 @@
     "@design-sdk/figma-node" "^0.0.43"
     "@design-sdk/figma-types" "^0.0.43"
 
-"@design-sdk/figma-node@^0.0.43":
-  version "0.0.43"
-  resolved "https://registry.yarnpkg.com/@design-sdk/figma-node/-/figma-node-0.0.43.tgz#5d468ae73e2b07a787d4e6447cdde7efb4f2ea43"
-  integrity sha512-Wo3jNL4S8NjqbwZZG4eXe2ut/HVM/vPGaEFoEa8MIJyTslwS+sobiU4TW2qDUYNVZW/L7fxYdHO+sBDQOx0TWw==
+"@design-sdk/figma-node@0.0.25", "@design-sdk/figma-node@^0.0.43":
+  version "0.0.25"
+  resolved "https://registry.yarnpkg.com/@design-sdk/figma-node/-/figma-node-0.0.25.tgz#c95484cc4b003667ae93e95fa3b585b9fa0b740a"
+  integrity sha512-GCA5cGDXhvGUQddmSIZgPMhH0eGip9S0yDSQiys1XiKnXsB/CM8/5C+JVosHR1WFMHSlJfU+ytA4IH2yhfysUQ==
   dependencies:
-    "@design-sdk/figma-core" "^0.0.43"
-    "@design-sdk/figma-utils" "^0.0.43"
+    "@design-sdk/figma-core" "^0.0.25"
+    "@design-sdk/figma-utils" "^0.0.25"
     "@reflect-ui/font-utils" "^0.0.1"
 
 "@design-sdk/figma-remote-api@^0.0.43":
@@ -1542,6 +1542,11 @@
   version "0.0.46"
   resolved "https://registry.yarnpkg.com/@design-sdk/figma-url/-/figma-url-0.0.46.tgz#8cf8eecbb80685480822734bfa871af6e5fa0daa"
   integrity sha512-9d8Og45cPxRe3Oh8wzWHhFrxZYfaoBdfP/J0OfYs2yTK7XY/vhz1GGf78aBjGdBdmaShHwfI8RHIhhV03nYKkg==
+
+"@design-sdk/figma-utils@^0.0.25":
+  version "0.0.25"
+  resolved "https://registry.yarnpkg.com/@design-sdk/figma-utils/-/figma-utils-0.0.25.tgz#7b7f6632fd8689ef713b27b34a61257accc2052e"
+  integrity sha512-HarFMa14L9zqg8rhLaCTXhTKFd6tlBno1mnSc/vl8ZVilmdq32OFFlmqS4MjyvrTfyAvbwlEMAhxV1SUQhFhRg==
 
 "@design-sdk/figma-utils@^0.0.43":
   version "0.0.43"
@@ -5869,19 +5874,7 @@
   resolved "https://registry.npmjs.org/@reflect-ui/cg/-/cg-0.0.5.tgz"
   integrity sha512-rqqaumLDgk9dGtPgkYy9h5PLlNv8ZVEz/+ktOcJpJE6v9fAQOSH1Wh5WAehpiZTQtKe944GzrFMsb/g8pTabWg==
 
-"@reflect-ui/core@0.0.2-rc.7":
-  version "0.0.2-rc.7"
-  resolved "https://registry.yarnpkg.com/@reflect-ui/core/-/core-0.0.2-rc.7.tgz#9d531f5a0b9caab31e7563020044b753700e2bbc"
-  integrity sha512-EqF4SRU57bfa5DOPET1rv5lROFyMVHLv1xTEIlN6N2gDpXt71QceImWfQp3z3Khqnb4R/p9OhNK6DXGUpozWKw==
-
-"@reflect-ui/core@0.0.5", "@reflect-ui/core@^0.0.5":
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@reflect-ui/core/-/core-0.0.5.tgz#f50ae00e64300c4b698ab5c5374c6ac3bb5de873"
-  integrity sha512-lA6AYHCF8aSyOvGXbJZcmlB5ccxCaznhxvD8Hg1UjVdhcbLhMWDbzoYqbrkqh+R4im3KnYw5n6pWSSdoWioYhA==
-  dependencies:
-    "@reflect-ui/uiutils" "^0.1.2-1"
-
-"@reflect-ui/core@^0.0.9":
+"@reflect-ui/core@0.0.2-rc.7", "@reflect-ui/core@0.0.5", "@reflect-ui/core@0.0.9", "@reflect-ui/core@^0.0.5", "@reflect-ui/core@^0.0.9":
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/@reflect-ui/core/-/core-0.0.9.tgz#7283a2a3a1edde16282559d11f02e23d3bceda36"
   integrity sha512-MNJq+Pc45qZ0IvTYuvzCW2nxupVRfMtmin9vepABo2h1sTKdAmCK2kPfVLea6TNiF1baJDeQg7IyAN45JMuFdA==
@@ -8285,28 +8278,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18.0.24":
+"@types/react@*", "@types/react@18.0.24", "@types/react@^17", "@types/react@^18.0.24", "@types/react@^18.0.25":
   version "18.0.24"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.24.tgz#2f79ed5b27f08d05107aab45c17919754cc44c20"
   integrity sha512-wRJWT6ouziGUy+9uX0aW4YOJxAY0bG6/AOk5AW5QSvZqI7dk6VBIbXvcVgIw/W5Jrl24f77df98GEKTJGOLx7Q==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^17":
-  version "17.0.55"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.55.tgz#f94eac1a37929cd86d1cc084c239c08dcfd10e5f"
-  integrity sha512-kBcAhmT8RivFDYxHdy8QfPKu+WyfiiGjdPb9pIRtd6tj05j0zRHq5DBGW5Ogxv5cwSKd93BVgUk/HZ4I9p3zNg==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^18.0.25":
-  version "18.0.31"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.31.tgz#a69ef8dd7bfa849734d258c793a8fe343a338205"
-  integrity sha512-EEG67of7DsvRDU6BLLI0p+k1GojDLz9+lZsnCpCRTa/lOokvyPBvp8S5x+A24hME3yyQuIipcP70KJ6H7Qupww==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -11284,15 +11259,10 @@ cssesc@^3.0.0:
   resolved "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
-csstype@^3.0.10, csstype@^3.0.2, csstype@^3.0.4, csstype@^3.0.8:
+csstype@3.1.0, csstype@^3.0.10, csstype@^3.0.2, csstype@^3.0.4, csstype@^3.0.8, csstype@^3.1.1:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.0.tgz#4ddcac3718d787cf9df0d1b7d15033925c8f29f2"
   integrity sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==
-
-csstype@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.1.tgz#841b532c45c758ee546a11d5bd7b7b473c8c30b9"
-  integrity sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==
 
 cuid@^2.1.8:
   version "2.1.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1467,10 +1467,10 @@
   resolved "https://registry.npmjs.org/@design-sdk/figma-auth-store/-/figma-auth-store-0.0.43.tgz"
   integrity sha512-5VF1EijfZwzOMq+r4ipQ0aDRk/JSUHOjg9cI7oaD+K+sw2YIjgxSBE05/tvncZhOpmFvDHSHTISYJfUsEWfSUQ==
 
-"@design-sdk/figma-core@^0.0.25":
-  version "0.0.25"
-  resolved "https://registry.yarnpkg.com/@design-sdk/figma-core/-/figma-core-0.0.25.tgz#7fa28cc7d6e45cd713c5f268d42e4dd4f2b41590"
-  integrity sha512-6OF7eUbDOlR4/BFtd2FRyDvvUf777OGNbVbNScUOv3Fk/kUXBzMTXX6ZdoRlTx887v/vo3+Lh0D31SG1sm80aA==
+"@design-sdk/figma-core@^0.0.43":
+  version "0.0.43"
+  resolved "https://registry.yarnpkg.com/@design-sdk/figma-core/-/figma-core-0.0.43.tgz#0d19d014daf398ed39046bfd4e7f3d2b78842943"
+  integrity sha512-7WQ29f4hUOxu4Mu8ZyqbBI5F4DsRJbIjGIcZAUmn7O9/SRR00upTYrl2hdlEnKdE0ImHTYqfISgxjkoYEQgZaQ==
 
 "@design-sdk/figma-node-conversion@^0.0.43":
   version "0.0.43"
@@ -1493,13 +1493,13 @@
     "@design-sdk/figma-node" "^0.0.43"
     "@design-sdk/figma-types" "^0.0.43"
 
-"@design-sdk/figma-node@0.0.25", "@design-sdk/figma-node@^0.0.43":
-  version "0.0.25"
-  resolved "https://registry.yarnpkg.com/@design-sdk/figma-node/-/figma-node-0.0.25.tgz#c95484cc4b003667ae93e95fa3b585b9fa0b740a"
-  integrity sha512-GCA5cGDXhvGUQddmSIZgPMhH0eGip9S0yDSQiys1XiKnXsB/CM8/5C+JVosHR1WFMHSlJfU+ytA4IH2yhfysUQ==
+"@design-sdk/figma-node@^0.0.43":
+  version "0.0.43"
+  resolved "https://registry.yarnpkg.com/@design-sdk/figma-node/-/figma-node-0.0.43.tgz#5d468ae73e2b07a787d4e6447cdde7efb4f2ea43"
+  integrity sha512-Wo3jNL4S8NjqbwZZG4eXe2ut/HVM/vPGaEFoEa8MIJyTslwS+sobiU4TW2qDUYNVZW/L7fxYdHO+sBDQOx0TWw==
   dependencies:
-    "@design-sdk/figma-core" "^0.0.25"
-    "@design-sdk/figma-utils" "^0.0.25"
+    "@design-sdk/figma-core" "^0.0.43"
+    "@design-sdk/figma-utils" "^0.0.43"
     "@reflect-ui/font-utils" "^0.0.1"
 
 "@design-sdk/figma-remote-api@^0.0.43":
@@ -1542,11 +1542,6 @@
   version "0.0.46"
   resolved "https://registry.yarnpkg.com/@design-sdk/figma-url/-/figma-url-0.0.46.tgz#8cf8eecbb80685480822734bfa871af6e5fa0daa"
   integrity sha512-9d8Og45cPxRe3Oh8wzWHhFrxZYfaoBdfP/J0OfYs2yTK7XY/vhz1GGf78aBjGdBdmaShHwfI8RHIhhV03nYKkg==
-
-"@design-sdk/figma-utils@^0.0.25":
-  version "0.0.25"
-  resolved "https://registry.yarnpkg.com/@design-sdk/figma-utils/-/figma-utils-0.0.25.tgz#7b7f6632fd8689ef713b27b34a61257accc2052e"
-  integrity sha512-HarFMa14L9zqg8rhLaCTXhTKFd6tlBno1mnSc/vl8ZVilmdq32OFFlmqS4MjyvrTfyAvbwlEMAhxV1SUQhFhRg==
 
 "@design-sdk/figma-utils@^0.0.43":
   version "0.0.43"
@@ -5874,7 +5869,19 @@
   resolved "https://registry.npmjs.org/@reflect-ui/cg/-/cg-0.0.5.tgz"
   integrity sha512-rqqaumLDgk9dGtPgkYy9h5PLlNv8ZVEz/+ktOcJpJE6v9fAQOSH1Wh5WAehpiZTQtKe944GzrFMsb/g8pTabWg==
 
-"@reflect-ui/core@0.0.2-rc.7", "@reflect-ui/core@0.0.5", "@reflect-ui/core@0.0.9", "@reflect-ui/core@^0.0.5", "@reflect-ui/core@^0.0.9":
+"@reflect-ui/core@0.0.2-rc.7":
+  version "0.0.2-rc.7"
+  resolved "https://registry.yarnpkg.com/@reflect-ui/core/-/core-0.0.2-rc.7.tgz#9d531f5a0b9caab31e7563020044b753700e2bbc"
+  integrity sha512-EqF4SRU57bfa5DOPET1rv5lROFyMVHLv1xTEIlN6N2gDpXt71QceImWfQp3z3Khqnb4R/p9OhNK6DXGUpozWKw==
+
+"@reflect-ui/core@0.0.5", "@reflect-ui/core@^0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@reflect-ui/core/-/core-0.0.5.tgz#f50ae00e64300c4b698ab5c5374c6ac3bb5de873"
+  integrity sha512-lA6AYHCF8aSyOvGXbJZcmlB5ccxCaznhxvD8Hg1UjVdhcbLhMWDbzoYqbrkqh+R4im3KnYw5n6pWSSdoWioYhA==
+  dependencies:
+    "@reflect-ui/uiutils" "^0.1.2-1"
+
+"@reflect-ui/core@^0.0.9":
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/@reflect-ui/core/-/core-0.0.9.tgz#7283a2a3a1edde16282559d11f02e23d3bceda36"
   integrity sha512-MNJq+Pc45qZ0IvTYuvzCW2nxupVRfMtmin9vepABo2h1sTKdAmCK2kPfVLea6TNiF1baJDeQg7IyAN45JMuFdA==
@@ -8278,10 +8285,28 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@18.0.24", "@types/react@^17", "@types/react@^18.0.24", "@types/react@^18.0.25":
+"@types/react@*", "@types/react@^18.0.24":
   version "18.0.24"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.24.tgz#2f79ed5b27f08d05107aab45c17919754cc44c20"
   integrity sha512-wRJWT6ouziGUy+9uX0aW4YOJxAY0bG6/AOk5AW5QSvZqI7dk6VBIbXvcVgIw/W5Jrl24f77df98GEKTJGOLx7Q==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@^17":
+  version "17.0.55"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.55.tgz#f94eac1a37929cd86d1cc084c239c08dcfd10e5f"
+  integrity sha512-kBcAhmT8RivFDYxHdy8QfPKu+WyfiiGjdPb9pIRtd6tj05j0zRHq5DBGW5Ogxv5cwSKd93BVgUk/HZ4I9p3zNg==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@^18.0.25":
+  version "18.0.31"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.31.tgz#a69ef8dd7bfa849734d258c793a8fe343a338205"
+  integrity sha512-EEG67of7DsvRDU6BLLI0p+k1GojDLz9+lZsnCpCRTa/lOokvyPBvp8S5x+A24hME3yyQuIipcP70KJ6H7Qupww==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -11259,10 +11284,15 @@ cssesc@^3.0.0:
   resolved "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
-csstype@3.1.0, csstype@^3.0.10, csstype@^3.0.2, csstype@^3.0.4, csstype@^3.0.8, csstype@^3.1.1:
+csstype@^3.0.10, csstype@^3.0.2, csstype@^3.0.4, csstype@^3.0.8:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.0.tgz#4ddcac3718d787cf9df0d1b7d15033925c8f29f2"
   integrity sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==
+
+csstype@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.1.tgz#841b532c45c758ee546a11d5bd7b7b473c8c30b9"
+  integrity sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==
 
 cuid@^2.1.8:
   version "2.1.8"
@@ -21805,6 +21835,11 @@ typescript@^4.4.4, typescript@^4.7.4, typescript@^4.8.4, typescript@^4.9.3:
   version "4.9.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz"
   integrity sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==
+
+ufo@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.1.1.tgz#e70265e7152f3aba425bd013d150b2cdf4056d7c"
+  integrity sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==
 
 uglify-js@^3.1.4:
   version "3.17.4"


### PR DESCRIPTION
Related - https://github.com/gridaco/code/issues/43


<img width="1537" alt="Screenshot 2023-04-01 at 6 23 45 AM" src="https://user-images.githubusercontent.com/16307013/229234334-842f8d86-2eac-4d20-aacc-6a0120505626.png">


This PR only affects `vanilla` framework. Google Fonts support is not implemented in any other frameworks.